### PR TITLE
Feat/codespaces support

### DIFF
--- a/.auth0/lab/environment.json
+++ b/.auth0/lab/environment.json
@@ -1,6 +1,6 @@
 {
   "name": "Lab Node Working with Connections",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "resources": "resources.yml",
   "unauthenticatedTour": ".auth0/lab/guides/signin.tour",
   "postConfigureTour": ".auth0/lab/guides/working-with-connections.tour",

--- a/.auth0/lab/environment.json
+++ b/.auth0/lab/environment.json
@@ -11,6 +11,7 @@
       "env": {
         "ISSUER_BASE_URL": "$tenant_base_url",
         "CLIENT_ID": "$client_id",
+        "CLIENT_SECRET": "$client_secret",
         "SESSION_SECRET": "a long, randomly-generated string stored in env",
         "PORT": 37500
       }

--- a/.auth0/lab/guides/signin.tour
+++ b/.auth0/lab/guides/signin.tour
@@ -1,6 +1,7 @@
 {
   "$schema": "https://aka.ms/codetour-schema",
   "title": "0: Sign in to Auth0",
+   "nextTour": "1: Working with Connections",
   "steps": [
     {
       "file": "README.md",

--- a/.auth0/lab/resources.yml
+++ b/.auth0/lab/resources.yml
@@ -6,5 +6,7 @@ clients: # Add other client settings https://auth0.com/docs/api/management/v2#!/
      alg: "RS256"
     callbacks:
       - "http://localhost:37500/callback"
+      - "https://*.preview.app.github.dev/callback"
     allowed_logout_urls:
       - "http://localhost:37500"
+      - "https://*.preview.app.github.dev"

--- a/src/web-app/env-config.js
+++ b/src/web-app/env-config.js
@@ -9,6 +9,15 @@ const {
 
 const appUrl = `http://localhost:${PORT}`;
 
+function checkEnvironment(){
+  // Use the Codespace App URL if we're in the Codespace environment
+  if(process.env.CODESPACE_NAME){
+    return `https://${process.env.CODESPACE_NAME}-${PORT}.${process.env.GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN}`
+  }
+  // otherwise use the localhost App URL
+  return appUrl;
+}
+
 function checkUrl() {
   return (req, res, next) => {
     const host = req.headers.host;
@@ -38,7 +47,7 @@ console.log('----------------------------------\n');
 
 module.exports = {
   checkUrl,
-  APP_URL: appUrl,
+  APP_URL: checkEnvironment(),
   API_URL: removeTrailingSlashFromUrl(API_URL),
   ISSUER_BASE_URL: removeTrailingSlashFromUrl(ISSUER_BASE_URL),
   CLIENT_ID: CLIENT_ID,

--- a/src/web-app/index.js
+++ b/src/web-app/index.js
@@ -40,12 +40,14 @@ app.use(
 
 app.use(
   auth({
+    authorizationParams: {
+        response_type: 'code',
+    },
     secret: SESSION_SECRET,
     auth0Logout: true,
     baseURL: APP_URL,
     issuerBaseURL: ISSUER_BASE_URL,
     clientID: CLIENT_ID,
-    authRequired: false,
   })
 );
 

--- a/src/web-app/index.js
+++ b/src/web-app/index.js
@@ -48,6 +48,7 @@ app.use(
     baseURL: APP_URL,
     issuerBaseURL: ISSUER_BASE_URL,
     clientID: CLIENT_ID,
+    authRequired: false,
   })
 );
 


### PR DESCRIPTION
Changes: Codespaces URL support, Web app now uses Auth Code, `environment.json` now specifies that the client secret should be written to the web app's `.env`, Codespaces wildcard URLs added to `resources.yml`

## Testing Instructions

1. Fork this repo into your personal GitHub (not just the main branch)
2. Switch to the feat/codespaces-support branch
3. Open this branch in Codespaces
4. Proceed through the lab steps as normal
5. Verify that:
- Your client secret is set in the web app's `.env` after configuring with the extension
- The Codespaces Wildcard URLs are added to your Lab: Web App Allowed URLs (check manage.auth0.com dashboard) after configuring with the extension
- The Codespaces app URL resolves correctly in the CodeTour and in the debug terminal
- You can authN into the app successfully